### PR TITLE
Changing locale to support utf-8 filenames

### DIFF
--- a/shells/compile.sh
+++ b/shells/compile.sh
@@ -31,6 +31,7 @@ command=$3
 outputFile=$4
 logFile=$5
 
+export LC_ALL=C.UTF-8
 cd $rootdir
 LATEXRUN="$(dirname $0)"/../latexrun/latexrun
 PYTHONUNBUFFERED=true $LATEXRUN --verbose-cmd --latex-cmd=${command} -Wall -o $outputFile $target &>$logFile


### PR DESCRIPTION
When submitting a .tar file, if it contains utf-8 filenames, the compilation breaks.

It is enough to use the locale `C.UTF-8` to avoid the problem.
