### PR TITLE
Use "npm ci" instead of "npm install"

### DIFF
--- a/util/docker-entrypoint.sh
+++ b/util/docker-entrypoint.sh
@@ -6,7 +6,7 @@ rm -rf /var/www
 # Copy and install the latest & greatest Latex-Online
 git clone https://github.com/aslushnikov/latex-online /var/www
 cd /var/www
-npm install .
+npm ci .
 
 export NODE_ENV=production
 export VERSION=$(git rev-parse HEAD)


### PR DESCRIPTION
When starting a docker container with the provided docker image I get the following error:
```
ReferenceError: globalThis is not defined at Object.<anonymous> (/usr/local/lib/node_modules/forever/node_modules/winston-transport/node_modules/readable-stream/lib/ours/util.js:5:21)
```

The error occurs since October 7th 2024. My assumption is, that one of the javascript packages got an upgrade and now uses a feature which is not available in the unstalled nodejs version.

This can be fixed by installing the packages defined in the package-lock.json. using `npm ci` instead of `npm install`.